### PR TITLE
add default env so we dont error if no env set in config

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -4,7 +4,7 @@ const { hasAnyDep } = require('./lib/utils')
 
 const explorerSync = cosmiconfigSync('eslint')
 const eslintrc = explorerSync.search()
-const { env } = eslintrc.config
+const { env = {} } = eslintrc.config
 
 const hasBabel = hasAnyDep('babel') || hasAnyDep('@babel/core')
 


### PR DESCRIPTION
Upon first run I ran into an error due to no env property being defined in .eslinrc, this should fix it.